### PR TITLE
Organic results cache

### DIFF
--- a/archive_query_log/archives/__init__.py
+++ b/archive_query_log/archives/__init__.py
@@ -69,7 +69,6 @@ def add_archive(
 
     archive = Archive(
         id=archive_id,
-        index=config.es.index_archives,
         last_modified=last_modified,
         name=name,
         description=description,
@@ -81,4 +80,4 @@ def add_archive(
     if dry_run:
         print(archive)
     else:
-        config.es.bulk([archive.index_action()])
+        archive.save(using=config.es.client, index=config.es.index_archives)

--- a/archive_query_log/archives/__init__.py
+++ b/archive_query_log/archives/__init__.py
@@ -69,6 +69,7 @@ def add_archive(
 
     archive = Archive(
         id=archive_id,
+        index=config.es.index_archives,
         last_modified=last_modified,
         name=name,
         description=description,
@@ -80,4 +81,4 @@ def add_archive(
     if dry_run:
         print(archive)
     else:
-        archive.save(using=config.es.client, index=config.es.index_archives)
+        config.es.bulk([archive.index_action()])

--- a/archive_query_log/captures/__init__.py
+++ b/archive_query_log/captures/__init__.py
@@ -249,12 +249,6 @@ def _organic_result_capture_update_action(
         updates["warc_location_after_serp"] = None
         updates["warc_downloader_after_serp"] = None
 
-    # Drop the search-relevance score, if set, since it must not end up in
-    # the update action's document body (unlike `id`/`index`/etc., which are
-    # needed to route the update, `score` is never a valid field to send).
-    result_block = result_block.model_copy()
-    result_block.__pydantic_fields_set__.discard("score")
-
     return result_block.update_action(**updates)
 
 

--- a/archive_query_log/captures/__init__.py
+++ b/archive_query_log/captures/__init__.py
@@ -71,48 +71,36 @@ def _iter_captures(
             NAMESPACE_CAPTURE,
             ":".join(capture_id_components),
         )
-        try:
-            capture = Capture(
-                id=capture_id,
-                last_modified=utc_now(),
-                archive=source.archive,
-                provider=source.provider,
-                url=HttpUrl(cdx_capture.url),
-                url_key=cdx_capture.url_key,
-                timestamp=cdx_capture.timestamp.astimezone(UTC),
-                status_code=cdx_capture.status_code,
-                digest=cdx_capture.digest,
-                mimetype=cdx_capture.mimetype,
-                filename=cdx_capture.filename,
-                offset=cdx_capture.offset,
-                length=cdx_capture.length,
-                access=cdx_capture.access,
-                redirect_url=HttpUrl(cdx_capture.redirect_url)
-                if cdx_capture.redirect_url is not None
-                else None,
-                flags=(
-                    [flag.value for flag in cdx_capture.flags]
-                    if cdx_capture.flags is not None
-                    else None
-                ),
-                collection=cdx_capture.collection,
-                source=cdx_capture.source,
-                source_collection=cdx_capture.source_collection,
-                url_query_parser=InnerParser(
-                    should_parse=True,
-                ),
-            )
-        except ValidationError as e:
-            # E.g., the URL may exceed the maximum length that `HttpUrl`
-            # accepts (much stricter than Elasticsearch's own limit checked
-            # above), or otherwise fail URL validation.
-            warn(
-                RuntimeWarning(
-                    f"Skipping invalid capture for URL {cdx_capture.url}: {e}"
-                )
-            )
-            continue
-        yield capture
+        yield Capture(
+            id=capture_id,
+            last_modified=utc_now(),
+            archive=source.archive,
+            provider=source.provider,
+            url=HttpUrl(cdx_capture.url),
+            url_key=cdx_capture.url_key,
+            timestamp=cdx_capture.timestamp.astimezone(UTC),
+            status_code=cdx_capture.status_code,
+            digest=cdx_capture.digest,
+            mimetype=cdx_capture.mimetype,
+            filename=cdx_capture.filename,
+            offset=cdx_capture.offset,
+            length=cdx_capture.length,
+            access=cdx_capture.access,
+            redirect_url=HttpUrl(cdx_capture.redirect_url)
+            if cdx_capture.redirect_url is not None
+            else None,
+            flags=(
+                [flag.value for flag in cdx_capture.flags]
+                if cdx_capture.flags is not None
+                else None
+            ),
+            collection=cdx_capture.collection,
+            source=cdx_capture.source,
+            source_collection=cdx_capture.source_collection,
+            url_query_parser=InnerParser(
+                should_parse=True,
+            ),
+        )
 
 
 def _add_captures_actions(

--- a/archive_query_log/captures/__init__.py
+++ b/archive_query_log/captures/__init__.py
@@ -8,7 +8,7 @@ from warnings import warn
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.function import RandomScore
 from elasticsearch_dsl.query import FunctionScore, RankFeature, Term, Range, Exists
-from pydantic import HttpUrl
+from pydantic import HttpUrl, ValidationError
 from requests import ConnectTimeout, HTTPError, Response
 from tqdm.auto import tqdm
 from web_archive_api.cdx import CdxApi, CdxMatchType, CdxCapture
@@ -71,36 +71,48 @@ def _iter_captures(
             NAMESPACE_CAPTURE,
             ":".join(capture_id_components),
         )
-        yield Capture(
-            id=capture_id,
-            last_modified=utc_now(),
-            archive=source.archive,
-            provider=source.provider,
-            url=HttpUrl(cdx_capture.url),
-            url_key=cdx_capture.url_key,
-            timestamp=cdx_capture.timestamp.astimezone(UTC),
-            status_code=cdx_capture.status_code,
-            digest=cdx_capture.digest,
-            mimetype=cdx_capture.mimetype,
-            filename=cdx_capture.filename,
-            offset=cdx_capture.offset,
-            length=cdx_capture.length,
-            access=cdx_capture.access,
-            redirect_url=HttpUrl(cdx_capture.redirect_url)
-            if cdx_capture.redirect_url is not None
-            else None,
-            flags=(
-                [flag.value for flag in cdx_capture.flags]
-                if cdx_capture.flags is not None
-                else None
-            ),
-            collection=cdx_capture.collection,
-            source=cdx_capture.source,
-            source_collection=cdx_capture.source_collection,
-            url_query_parser=InnerParser(
-                should_parse=True,
-            ),
-        )
+        try:
+            capture = Capture(
+                id=capture_id,
+                last_modified=utc_now(),
+                archive=source.archive,
+                provider=source.provider,
+                url=HttpUrl(cdx_capture.url),
+                url_key=cdx_capture.url_key,
+                timestamp=cdx_capture.timestamp.astimezone(UTC),
+                status_code=cdx_capture.status_code,
+                digest=cdx_capture.digest,
+                mimetype=cdx_capture.mimetype,
+                filename=cdx_capture.filename,
+                offset=cdx_capture.offset,
+                length=cdx_capture.length,
+                access=cdx_capture.access,
+                redirect_url=HttpUrl(cdx_capture.redirect_url)
+                if cdx_capture.redirect_url is not None
+                else None,
+                flags=(
+                    [flag.value for flag in cdx_capture.flags]
+                    if cdx_capture.flags is not None
+                    else None
+                ),
+                collection=cdx_capture.collection,
+                source=cdx_capture.source,
+                source_collection=cdx_capture.source_collection,
+                url_query_parser=InnerParser(
+                    should_parse=True,
+                ),
+            )
+        except ValidationError as e:
+            # E.g., the URL may exceed the maximum length that `HttpUrl`
+            # accepts (much stricter than Elasticsearch's own limit checked
+            # above), or otherwise fail URL validation.
+            warn(
+                RuntimeWarning(
+                    f"Skipping invalid capture for URL {cdx_capture.url}: {e}"
+                )
+            )
+            continue
+        yield capture
 
 
 def _add_captures_actions(
@@ -122,7 +134,12 @@ def _add_captures_actions(
     try:
         for capture in captures_iter:
             capture.index = config.es.index_captures
-            yield capture.create_action()
+            # Use an idempotent upsert instead of a failing create, since a
+            # capture's id is a deterministic hash of its CDX identity, so a
+            # duplicate id always means identical content (e.g., duplicate
+            # rows across CDX pagination boundaries, or a re-fetch after an
+            # interrupted run).
+            yield capture.index_action()
     except ConnectTimeout as e:
         # The archives' CDX are usually very slow, so we expect timeouts.
         # Rather than failing, we just warn and continue with the next source.
@@ -243,6 +260,12 @@ def _organic_result_capture_update_action(
     if capture_after_serp != result_block.capture_after_serp:
         updates["warc_location_after_serp"] = None
         updates["warc_downloader_after_serp"] = None
+
+    # Drop the search-relevance score, if set, since it must not end up in
+    # the update action's document body (unlike `id`/`index`/etc., which are
+    # needed to route the update, `score` is never a valid field to send).
+    result_block = result_block.model_copy()
+    result_block.__pydantic_fields_set__.discard("score")
 
     return result_block.update_action(**updates)
 

--- a/archive_query_log/captures/__init__.py
+++ b/archive_query_log/captures/__init__.py
@@ -121,7 +121,7 @@ def _add_captures_actions(
     captures_iter = _iter_captures(config, source)
     try:
         for capture in captures_iter:
-            capture.meta.index = config.es.index_captures
+            capture.index = config.es.index_captures
             yield capture.create_action()
     except ConnectTimeout as e:
         # The archives' CDX are usually very slow, so we expect timeouts.

--- a/archive_query_log/cli/organic_results.py
+++ b/archive_query_log/cli/organic_results.py
@@ -1,5 +1,5 @@
 from cyclopts import App
-from cyclopts.types import ResolvedPath, PositiveInt
+from cyclopts.types import PositiveInt, ResolvedPath
 
 from archive_query_log.config import Config
 from archive_query_log.export.base import ExportFormat
@@ -59,7 +59,7 @@ def download_warc_before_serp(
     config: Config = Config(),
 ) -> None:
     """
-    Download archived contents of web search result block landing page captures as WARC to S3.
+    Download archived contents of web search result block landing page captures as WARC to file cache.
 
     :param size: How many web search result block landing pages to download.
     """
@@ -84,7 +84,7 @@ def download_warc_after_serp(
     config: Config = Config(),
 ) -> None:
     """
-    Download archived contents of web search result block landing page captures as WARC to S3.
+    Download archived contents of web search result block landing page captures as WARC to file cache.
 
     :param size: How many web search result block landing pages to download.
     """
@@ -144,3 +144,22 @@ def export_all(
         output_path=output_path,
         config=config,
     )
+
+upload = App(
+    name="upload",
+    alias="u",
+    help="Upload web search result block landing pages.",
+)
+organic_results.command(upload)
+
+@upload.command(name="warc")
+def upload_warc(
+    *,
+    config: Config = Config(),
+) -> None:
+    """
+    Upload WARCs of archived contents of organic result captures to S3 and update the index.
+    """
+    from archive_query_log.downloaders.warc import upload_organic_results_warc
+
+    upload_organic_results_warc(config)

--- a/archive_query_log/downloaders/warc.py
+++ b/archive_query_log/downloaders/warc.py
@@ -1,20 +1,18 @@
 from dataclasses import dataclass
 from itertools import chain
-from json import loads, dumps
+from json import dumps, loads
 from pathlib import Path
-from typing import Iterable, Iterator, TypeVar, Generic, Type, Callable, cast
+from typing import Callable, Generic, Iterable, Iterator, Type, TypeVar
 from uuid import UUID, uuid5
 from warnings import warn
 
 from elasticsearch_dsl import Search
 from elasticsearch_dsl.function import RandomScore
-from elasticsearch_dsl.query import FunctionScore, Term, RankFeature
-
-from elasticsearch_dsl.query import Exists
+from elasticsearch_dsl.query import Exists, FunctionScore, RankFeature, Term
 from requests import ConnectionError as RequestsConnectionError
 from tqdm.auto import tqdm
-from warc_cache import WarcCacheStore, WarcCacheRecord
-from warc_s3 import WarcS3Store, WarcS3Record
+from warc_cache import WarcCacheRecord, WarcCacheStore
+from warc_s3 import WarcS3Store
 from warcio.recordloader import ArcWarcRecord
 from web_archive_api.memento import MementoApi
 
@@ -22,14 +20,13 @@ from archive_query_log import __version__ as app_version
 from archive_query_log.config import Config
 from archive_query_log.namespaces import NAMESPACE_WARC_DOWNLOADER
 from archive_query_log.orm import (
-    Serp,
     InnerDownloader,
-    WarcLocation,
     OrganicResult,
+    Serp,
     UuidBaseDocument,
+    WarcLocation,
 )
 from archive_query_log.utils.time import utc_now
-
 
 _D = TypeVar("_D", bound=UuidBaseDocument)
 
@@ -80,6 +77,17 @@ class _AnnotatedWarcRecord(ArcWarcRecord, Generic[_T]):
             digest_checker=record.digest_checker,
         )
         self.annotation = annotation
+
+
+class _PseudoOrganicResult(UuidBaseDocument):
+    before_serp: bool
+    # `update_action()` only dumps fields declared on the model itself, so
+    # the fields it is called with below must be declared here too, even
+    # though this pseudo document never actually sets them.
+    warc_location_before_serp: WarcLocation | None = None
+    warc_downloader_before_serp: InnerDownloader | None = None
+    warc_location_after_serp: WarcLocation | None = None
+    warc_downloader_after_serp: InnerDownloader | None = None
 
 
 def _warc_downloader_id(config: Config) -> UUID:
@@ -349,7 +357,7 @@ def _download_organic_result_warc(
     config: Config,
     result_block: OrganicResult,
     before_serp: bool,
-) -> Iterator[_AnnotatedWarcRecord[OrganicResult]]:
+) -> Iterator[_WrapperWarcRecord[_PseudoOrganicResult]]:
     capture = (
         result_block.capture_before_serp
         if before_serp
@@ -378,27 +386,20 @@ def _download_organic_result_warc(
         )
         return
 
+    # Only keep the meta fields needed to route the update, since
+    # `update_action()` serializes any other set meta field (e.g. `seq_no`)
+    # under a key Elasticsearch's update API does not accept.
+    pseudo_result = _PseudoOrganicResult(
+        id=result_block.id,
+        index=result_block.index,
+        before_serp=before_serp,
+    )
     for record in records:
-        yield _AnnotatedWarcRecord(record, result_block)
-
-
-def _unwrap_records(
-    record: Iterable[WarcS3Record], wrapper_type: Type[_D]
-) -> Iterator[tuple[_D, WarcLocation]]:
-    for stored_record in record:
-        location = WarcLocation(
-            file=stored_record.location.key,
-            offset=stored_record.location.offset,
-            length=stored_record.location.length,
-        )
-
-        annotated_record = cast(_AnnotatedWarcRecord[_D], stored_record.record)
-        annotation = annotated_record.annotation
-        yield annotation, location
+        yield _WrapperWarcRecord(record, pseudo_result)
 
 
 def _organic_result_warc_update_action(
-    result_block: OrganicResult,
+    result_block: UuidBaseDocument,
     location: WarcLocation,
     downloader_id: UUID,
     before_serp: bool,
@@ -474,24 +475,13 @@ def _download_organic_results_warc(
         for result_block in changed_result_blocks
     )
 
-    # Write to S3.
-    stored_records: Iterator[WarcS3Record] = config.s3.warc_s3_store.write(
+    # Write to cache.
+    locations: Iterator[WarcCacheRecord] = config.warc_cache.store_results.write(
         downloaded_records
     )
-    stored_result_blocks = _unwrap_records(stored_records, OrganicResult)
 
-    # Update Elasticsearch.
-    downloader_id = _warc_downloader_id(config)
-    actions = (
-        _organic_result_warc_update_action(
-            result_block=result_block,
-            location=location,
-            downloader_id=downloader_id,
-            before_serp=before_serp,
-        )
-        for result_block, location in stored_result_blocks
-    )
-    config.es.bulk(actions)
+    for _ in locations:
+        pass
 
 
 def download_organic_result_warc_before_serp(
@@ -512,3 +502,41 @@ def download_organic_result_warc_after_serp(
         size=size,
         before_serp=False,
     )
+
+
+def upload_organic_results_warc(
+    config: Config,
+) -> None:
+    # Read from cache.
+    cached_records = _iter_cached_records(warc_store=config.warc_cache.store_results)
+
+    # Parse wrapped records (document visible in a WARC header).
+    wrapped_records = _iter_wrapped_records(
+        records=cached_records,
+        wrapped_type=_PseudoOrganicResult,
+    )
+
+    # Transform to annotated records (document opaque to the actual WARC record).
+    annotated_records = _iter_annotated_records(
+        records=wrapped_records,
+    )
+        
+    # Write to S3.
+    stored_pseudo_results = _iter_s3_stored_records(
+        records=annotated_records,
+        warc_store=config.s3.warc_s3_store,
+        document_type=_PseudoOrganicResult,
+    )
+
+    # Update Elasticsearch.
+    downloader_id = _warc_downloader_id(config)
+    actions = (
+        _organic_result_warc_update_action(
+            result_block=pseudo_result,
+            location=location,
+            downloader_id=downloader_id,
+            before_serp=pseudo_result.before_serp,
+        )
+        for pseudo_result, location in stored_pseudo_results
+    )
+    config.es.bulk(actions)

--- a/archive_query_log/downloaders/warc.py
+++ b/archive_query_log/downloaders/warc.py
@@ -399,20 +399,22 @@ def _download_organic_result_warc(
 
 
 def _organic_result_warc_update_action(
-    result_block: UuidBaseDocument,
+    result_block: _PseudoOrganicResult,
     location: WarcLocation,
     downloader_id: UUID,
-    before_serp: bool,
 ) -> dict:
     downloader = InnerDownloader(
         id=downloader_id,
         should_download=False,
         last_downloaded=utc_now(),
     )
-    # The field names must match the ones queried in
-    # `_download_organic_results_warc()`, otherwise the downloaded
-    # blocks are never marked as downloaded and would be downloaded again.
-    if before_serp:
+    # Only keep the meta fields of the organic result, as the source is not needed for updating it.
+    result_block = UuidBaseDocument(
+        id=result_block.id,
+        index=result_block.index,
+        seq_no=result_block.seq_no
+    )
+    if result_block.before_serp:
         return result_block.update_action(
             warc_location_before_serp=location,
             warc_downloader_before_serp=downloader,
@@ -535,7 +537,6 @@ def upload_organic_results_warc(
             result_block=pseudo_result,
             location=location,
             downloader_id=downloader_id,
-            before_serp=pseudo_result.before_serp,
         )
         for pseudo_result, location in stored_pseudo_results
     )

--- a/archive_query_log/imports/aql22.py
+++ b/archive_query_log/imports/aql22.py
@@ -143,7 +143,7 @@ def _import_captures_path(
 
 
 def _create_action(capture: Capture, config: Config) -> dict:
-    capture.meta.index = config.es.index_captures
+    capture.index = config.es.index_captures
     return {
         **capture.to_dict(include_meta=True),
         "_op_type": "create",

--- a/archive_query_log/imports/yaml.py
+++ b/archive_query_log/imports/yaml.py
@@ -5,7 +5,7 @@ from typing import Sequence, Iterable
 from diskcache import Index
 from tqdm.auto import tqdm
 from whois import whois
-from whois.parser import PywhoisError
+from whois.exceptions import PywhoisError
 from yaml import safe_load
 
 from archive_query_log.config import Config

--- a/archive_query_log/orm.py
+++ b/archive_query_log/orm.py
@@ -1,26 +1,41 @@
-from datetime import datetime, UTC
-from typing import Annotated, TypeAlias, Sequence
+from datetime import UTC, datetime
+from typing import Annotated, Sequence, TypeAlias
 from uuid import UUID
 
 from annotated_types import Ge
 from elasticsearch_dsl import (
-    Date as _Date,
-    RankFeature as _RankFeature,
-    Keyword as _Keyword,
-    Text as _Text,
     Completion as _Completion,
 )
-from pydantic import Field, AliasChoices, computed_field, AnyHttpUrl
-from pydantic_extra_types.language_code import LanguageAlpha2
-
+from elasticsearch_dsl import (
+    Date as _Date,
+)
+from elasticsearch_dsl import (
+    Keyword as _Keyword,
+)
+from elasticsearch_dsl import (
+    RankFeature as _RankFeature,
+)
+from elasticsearch_dsl import (
+    Text as _Text,
+)
 from elasticsearch_pydantic import (
     BaseDocument,
     BaseInnerDocument,
-    KeywordField as Keyword,
-    TextField as Text,
+)
+from elasticsearch_pydantic import (
     IntegerField as Integer,
+)
+from elasticsearch_pydantic import (
+    KeywordField as Keyword,
+)
+from elasticsearch_pydantic import (
     LongField as Long,
 )
+from elasticsearch_pydantic import (
+    TextField as Text,
+)
+from pydantic import AliasChoices, AnyHttpUrl, Field, computed_field
+from pydantic_extra_types.language_code import LanguageAlpha2
 
 TextWithSuggestAndKeyword: TypeAlias = Annotated[
     str,

--- a/archive_query_log/parsers/url_query.py
+++ b/archive_query_log/parsers/url_query.py
@@ -116,13 +116,6 @@ def parse_serp_url_query_action(
     ):
         return
 
-    # Drop the search-relevance score, if set, since `update_action()` only
-    # dumps fields declared on the model itself, and a minimal pseudo
-    # document wouldn't declare `url_query_parser` at all, while the score
-    # must not end up in the update action's document body.
-    capture = capture.model_copy()
-    capture.__pydantic_fields_set__.discard("score")
-
     for parser in URL_QUERY_PARSERS:
         if not parser.is_applicable(capture):
             continue

--- a/archive_query_log/parsers/url_query.py
+++ b/archive_query_log/parsers/url_query.py
@@ -116,6 +116,13 @@ def parse_serp_url_query_action(
     ):
         return
 
+    # Drop the search-relevance score, if set, since `update_action()` only
+    # dumps fields declared on the model itself, and a minimal pseudo
+    # document wouldn't declare `url_query_parser` at all, while the score
+    # must not end up in the update action's document body.
+    capture = capture.model_copy()
+    capture.__pydantic_fields_set__.discard("score")
+
     for parser in URL_QUERY_PARSERS:
         if not parser.is_applicable(capture):
             continue

--- a/archive_query_log/providers/__init__.py
+++ b/archive_query_log/providers/__init__.py
@@ -91,7 +91,6 @@ def add_provider(
 
     provider = Provider(
         id=provider_id,
-        index=config.es.index_providers,
         last_modified=last_modified,
         name=name,
         description=description,
@@ -103,6 +102,6 @@ def add_provider(
         should_build_sources=should_build_sources,
     )
     if not dry_run:
-        config.es.bulk([provider.index_action()])
+        provider.save(using=config.es.client, index=config.es.index_providers)
     else:
         print(provider)

--- a/archive_query_log/providers/__init__.py
+++ b/archive_query_log/providers/__init__.py
@@ -91,6 +91,7 @@ def add_provider(
 
     provider = Provider(
         id=provider_id,
+        index=config.es.index_providers,
         last_modified=last_modified,
         name=name,
         description=description,
@@ -102,6 +103,6 @@ def add_provider(
         should_build_sources=should_build_sources,
     )
     if not dry_run:
-        provider.save(using=config.es.client, index=config.es.index_providers)
+        config.es.bulk([provider.index_action()])
     else:
         print(provider)

--- a/archive_query_log/sources/__init__.py
+++ b/archive_query_log/sources/__init__.py
@@ -16,7 +16,6 @@ from archive_query_log.orm import (
     Source,
     InnerArchive,
     InnerProvider,
-    UuidBaseDocument,
 )
 from archive_query_log.utils.time import utc_now
 
@@ -82,11 +81,14 @@ def _iter_sources_batches_changed_archives(
                 provider,
                 config,
             )
-        # Only keep the meta fields, since e.g. the search-relevance score
-        # must not end up in the update action's document body.
-        pseudo_archive = UuidBaseDocument(id=archive.id, index=archive.index)
+        # Drop the search-relevance score, if set, since `update_action()`
+        # only dumps fields declared on the model itself, and a minimal
+        # pseudo document wouldn't declare `should_build_sources` at all,
+        # while the score must not end up in the update action's body.
+        archive = archive.model_copy()
+        archive.__pydantic_fields_set__.discard("score")
         yield [
-            pseudo_archive.update_action(
+            archive.update_action(
                 should_build_sources=False,
                 last_built_sources=utc_now(),
             )
@@ -111,11 +113,14 @@ def _iter_sources_batches_changed_providers(
                 provider,
                 config,
             )
-        # Only keep the meta fields, since e.g. the search-relevance score
-        # must not end up in the update action's document body.
-        pseudo_provider = UuidBaseDocument(id=provider.id, index=provider.index)
+        # Drop the search-relevance score, if set, since `update_action()`
+        # only dumps fields declared on the model itself, and a minimal
+        # pseudo document wouldn't declare `should_build_sources` at all,
+        # while the score must not end up in the update action's body.
+        provider = provider.model_copy()
+        provider.__pydantic_fields_set__.discard("score")
         yield [
-            pseudo_provider.update_action(
+            provider.update_action(
                 should_build_sources=False,
                 last_built_sources=utc_now(),
             )

--- a/archive_query_log/sources/__init__.py
+++ b/archive_query_log/sources/__init__.py
@@ -10,7 +10,14 @@ from tqdm.auto import tqdm
 
 from archive_query_log.config import Config
 from archive_query_log.namespaces import NAMESPACE_SOURCE
-from archive_query_log.orm import Archive, Provider, Source, InnerArchive, InnerProvider
+from archive_query_log.orm import (
+    Archive,
+    Provider,
+    Source,
+    InnerArchive,
+    InnerProvider,
+    UuidBaseDocument,
+)
 from archive_query_log.utils.time import utc_now
 
 
@@ -52,7 +59,7 @@ def _sources_batch(archive: Archive, provider: Provider, config: Config) -> list
                 ),
                 should_fetch_captures=True,
             )
-            source.meta.index = config.es.index_sources
+            source.index = config.es.index_sources
             batch.append(source.create_action())
     return batch
 
@@ -75,8 +82,11 @@ def _iter_sources_batches_changed_archives(
                 provider,
                 config,
             )
+        # Only keep the meta fields, since e.g. the search-relevance score
+        # must not end up in the update action's document body.
+        pseudo_archive = UuidBaseDocument(id=archive.id, index=archive.index)
         yield [
-            archive.update_action(
+            pseudo_archive.update_action(
                 should_build_sources=False,
                 last_built_sources=utc_now(),
             )
@@ -101,8 +111,11 @@ def _iter_sources_batches_changed_providers(
                 provider,
                 config,
             )
+        # Only keep the meta fields, since e.g. the search-relevance score
+        # must not end up in the update action's document body.
+        pseudo_provider = UuidBaseDocument(id=provider.id, index=provider.index)
         yield [
-            provider.update_action(
+            pseudo_provider.update_action(
                 should_build_sources=False,
                 last_built_sources=utc_now(),
             )

--- a/archive_query_log/sources/__init__.py
+++ b/archive_query_log/sources/__init__.py
@@ -81,12 +81,6 @@ def _iter_sources_batches_changed_archives(
                 provider,
                 config,
             )
-        # Drop the search-relevance score, if set, since `update_action()`
-        # only dumps fields declared on the model itself, and a minimal
-        # pseudo document wouldn't declare `should_build_sources` at all,
-        # while the score must not end up in the update action's body.
-        archive = archive.model_copy()
-        archive.__pydantic_fields_set__.discard("score")
         yield [
             archive.update_action(
                 should_build_sources=False,
@@ -113,12 +107,6 @@ def _iter_sources_batches_changed_providers(
                 provider,
                 config,
             )
-        # Drop the search-relevance score, if set, since `update_action()`
-        # only dumps fields declared on the model itself, and a minimal
-        # pseudo document wouldn't declare `should_build_sources` at all,
-        # while the score must not end up in the update action's body.
-        provider = provider.model_copy()
-        provider.__pydantic_fields_set__.discard("score")
         yield [
             provider.update_action(
                 should_build_sources=False,

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -9,8 +9,14 @@ Started workers:
 - Parse SERP URL pages (replicas: {{ $.Values.serpsParseUrlPage.replicas }}).
 - Parse SERP URL offsets (replicas: {{ $.Values.serpsParseUrlOffset.replicas }}).
 - Download SERP WARCs (replicas: {{ $.Values.serpsDownloadWarc.replicas }}).
+- Upload SERP WARCs (replicas: {{ $.Values.serpsUploadWarc.replicas }}).
 - Parse SERP WARC queries (replicas: {{ $.Values.serpsParseWarcQuery.replicas }}).
-- Parse SERP WARC queries (replicas: {{ $.Values.serpsParseWarcSnippets.replicas }}).
+- Parse SERP WARC organic results (replicas: {{ $.Values.serpsParseWarcOrganicResults.replicas }}).
+- Parse SERP WARC features (replicas: {{ $.Values.serpsParseWarcFeatures.replicas }}).
+- Fetch organic result captures (replicas: {{ $.Values.organicResultsFetchCaptures.replicas }}).
+- Download organic result WARCs before SERP (replicas: {{ $.Values.organicResultsDownloadWarcBeforeSerp.replicas }}).
+- Download organic result WARCs after SERP (replicas: {{ $.Values.organicResultsDownloadWarcAfterSerp.replicas }}).
+- Upload organic result WARCs (replicas: {{ $.Values.organicResultsUploadWarc.replicas }}).
 {{- if $.Values.capturesImportAql22.enabled }}
 
 Started jobs:

--- a/helm/templates/captures-fetch.yml
+++ b/helm/templates/captures-fetch.yml
@@ -31,8 +31,8 @@ spec:
             - archive_query_log
             - captures
             - fetch
-            - --prefetch-limit
-            - '{{ $.Values.capturesFetch.prefetchLimit }}'
+            - --size
+            - '{{ $.Values.capturesFetch.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -58,22 +58,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/captures-import-aql-22.yml
+++ b/helm/templates/captures-import-aql-22.yml
@@ -60,22 +60,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/monitoring.yml
+++ b/helm/templates/monitoring.yml
@@ -58,22 +58,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/organic-results-download-warc-after-serp.yml
+++ b/helm/templates/organic-results-download-warc-after-serp.yml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-organic-results-download-warc-after-serp
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-organic-results-download-warc-after-serp
+  replicas: {{ $.Values.organicResultsDownloadWarcAfterSerp.replicas }}
+  revisionHistoryLimit: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-organic-results-download-warc-after-serp
+    spec:
+      containers:
+        - name: {{ $.Release.Name }}-organic-results-download-warc-after-serp
+          image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 4Gi
+          command:
+            - /usr/bin/timeout
+            - "86400" # 24 hours
+            - /venv/bin/python
+            - -m
+            - archive_query_log
+            - web-search-result-blocks
+            - download
+            - warc-after-serp
+            - --size
+            - '{{ $.Values.organicResultsDownloadWarcAfterSerp.size }}'
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: {{ $.Values.elasticsearch.host | quote }}
+            - name: ELASTICSEARCH_PORT
+              value: {{ $.Values.elasticsearch.port | quote }}
+            - name: ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchUsername
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchPassword
+            - name: ELASTICSEARCH_INDEX_ARCHIVES
+              value: {{ $.Values.elasticsearch.indexArchives | quote }}
+            - name: ELASTICSEARCH_INDEX_PROVIDERS
+              value: {{ $.Values.elasticsearch.indexProviders | quote }}
+            - name: ELASTICSEARCH_INDEX_SOURCES
+              value: {{ $.Values.elasticsearch.indexSources | quote }}
+            - name: ELASTICSEARCH_INDEX_CAPTURES
+              value: {{ $.Values.elasticsearch.indexCaptures | quote }}
+            - name: ELASTICSEARCH_INDEX_SERPS
+              value: {{ $.Values.elasticsearch.indexSerps | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
+            - name: S3_ENDPOINT_URL
+              value: {{ $.Values.s3.endpointUrl | quote }}
+            - name: S3_BUCKET_NAME
+              value: {{ $.Values.s3.bucketName | quote }}
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3AccessKey
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3SecretKey
+            - name: WARC_CACHE_PATH_RESULTS
+              value: {{ $.Values.warcCache.pathResults | quote }}
+          volumeMounts:
+            - name: {{ $.Release.Name }}-warc-cache-path-results
+              mountPath: {{ $.Values.warcCache.pathResults }}
+      volumes:
+        - name: {{ $.Release.Name }}-warc-cache-path-results
+          hostPath:
+            path: {{ $.Values.warcCache.pathResults }}
+            type: DirectoryOrCreate

--- a/helm/templates/organic-results-download-warc-before-serp.yml
+++ b/helm/templates/organic-results-download-warc-before-serp.yml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-organic-results-download-warc-before-serp
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-organic-results-download-warc-before-serp
+  replicas: {{ $.Values.organicResultsDownloadWarcBeforeSerp.replicas }}
+  revisionHistoryLimit: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-organic-results-download-warc-before-serp
+    spec:
+      containers:
+        - name: {{ $.Release.Name }}-organic-results-download-warc-before-serp
+          image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 4Gi
+          command:
+            - /usr/bin/timeout
+            - "86400" # 24 hours
+            - /venv/bin/python
+            - -m
+            - archive_query_log
+            - web-search-result-blocks
+            - download
+            - warc-before-serp
+            - --size
+            - '{{ $.Values.organicResultsDownloadWarcBeforeSerp.size }}'
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: {{ $.Values.elasticsearch.host | quote }}
+            - name: ELASTICSEARCH_PORT
+              value: {{ $.Values.elasticsearch.port | quote }}
+            - name: ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchUsername
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchPassword
+            - name: ELASTICSEARCH_INDEX_ARCHIVES
+              value: {{ $.Values.elasticsearch.indexArchives | quote }}
+            - name: ELASTICSEARCH_INDEX_PROVIDERS
+              value: {{ $.Values.elasticsearch.indexProviders | quote }}
+            - name: ELASTICSEARCH_INDEX_SOURCES
+              value: {{ $.Values.elasticsearch.indexSources | quote }}
+            - name: ELASTICSEARCH_INDEX_CAPTURES
+              value: {{ $.Values.elasticsearch.indexCaptures | quote }}
+            - name: ELASTICSEARCH_INDEX_SERPS
+              value: {{ $.Values.elasticsearch.indexSerps | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
+            - name: S3_ENDPOINT_URL
+              value: {{ $.Values.s3.endpointUrl | quote }}
+            - name: S3_BUCKET_NAME
+              value: {{ $.Values.s3.bucketName | quote }}
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3AccessKey
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3SecretKey
+            - name: WARC_CACHE_PATH_RESULTS
+              value: {{ $.Values.warcCache.pathResults | quote }}
+          volumeMounts:
+            - name: {{ $.Release.Name }}-warc-cache-path-results
+              mountPath: {{ $.Values.warcCache.pathResults }}
+      volumes:
+        - name: {{ $.Release.Name }}-warc-cache-path-results
+          hostPath:
+            path: {{ $.Values.warcCache.pathResults }}
+            type: DirectoryOrCreate

--- a/helm/templates/organic-results-fetch-captures.yml
+++ b/helm/templates/organic-results-fetch-captures.yml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-organic-results-fetch-captures
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-organic-results-fetch-captures
+  replicas: {{ $.Values.organicResultsFetchCaptures.replicas }}
+  revisionHistoryLimit: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-organic-results-fetch-captures
+    spec:
+      containers:
+        - name: {{ $.Release.Name }}-organic-results-fetch-captures
+          image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 4Gi
+          command:
+            - /usr/bin/timeout
+            - "86400" # 24 hours
+            - /venv/bin/python
+            - -m
+            - archive_query_log
+            - web-search-result-blocks
+            - fetch-captures
+            - --size
+            - '{{ $.Values.organicResultsFetchCaptures.size }}'
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: {{ $.Values.elasticsearch.host | quote }}
+            - name: ELASTICSEARCH_PORT
+              value: {{ $.Values.elasticsearch.port | quote }}
+            - name: ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchUsername
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchPassword
+            - name: ELASTICSEARCH_INDEX_ARCHIVES
+              value: {{ $.Values.elasticsearch.indexArchives | quote }}
+            - name: ELASTICSEARCH_INDEX_PROVIDERS
+              value: {{ $.Values.elasticsearch.indexProviders | quote }}
+            - name: ELASTICSEARCH_INDEX_SOURCES
+              value: {{ $.Values.elasticsearch.indexSources | quote }}
+            - name: ELASTICSEARCH_INDEX_CAPTURES
+              value: {{ $.Values.elasticsearch.indexCaptures | quote }}
+            - name: ELASTICSEARCH_INDEX_SERPS
+              value: {{ $.Values.elasticsearch.indexSerps | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
+            - name: S3_ENDPOINT_URL
+              value: {{ $.Values.s3.endpointUrl | quote }}
+            - name: S3_BUCKET_NAME
+              value: {{ $.Values.s3.bucketName | quote }}
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3AccessKey
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3SecretKey
+            - name: WARC_CACHE_PATH_RESULTS
+              value: {{ $.Values.warcCache.pathResults | quote }}
+          volumeMounts:
+            - name: {{ $.Release.Name }}-warc-cache-path-results
+              mountPath: {{ $.Values.warcCache.pathResults }}
+      volumes:
+        - name: {{ $.Release.Name }}-warc-cache-path-results
+          hostPath:
+            path: {{ $.Values.warcCache.pathResults }}
+            type: DirectoryOrCreate

--- a/helm/templates/organic-results-upload-warc.yml
+++ b/helm/templates/organic-results-upload-warc.yml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}-organic-results-upload-warc
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-organic-results-upload-warc
+  replicas: {{ $.Values.organicResultsUploadWarc.replicas }}
+  revisionHistoryLimit: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $.Release.Name }}-organic-results-upload-warc
+    spec:
+      containers:
+        - name: {{ $.Release.Name }}-organic-results-upload-warc
+          image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 4Gi
+          command:
+            - /usr/bin/timeout
+            - "86400" # 24 hours
+            - /venv/bin/python
+            - -m
+            - archive_query_log
+            - web-search-result-blocks
+            - upload
+            - warc
+          env:
+            - name: ELASTICSEARCH_HOST
+              value: {{ $.Values.elasticsearch.host | quote }}
+            - name: ELASTICSEARCH_PORT
+              value: {{ $.Values.elasticsearch.port | quote }}
+            - name: ELASTICSEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchUsername
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: elasticsearchPassword
+            - name: ELASTICSEARCH_INDEX_ARCHIVES
+              value: {{ $.Values.elasticsearch.indexArchives | quote }}
+            - name: ELASTICSEARCH_INDEX_PROVIDERS
+              value: {{ $.Values.elasticsearch.indexProviders | quote }}
+            - name: ELASTICSEARCH_INDEX_SOURCES
+              value: {{ $.Values.elasticsearch.indexSources | quote }}
+            - name: ELASTICSEARCH_INDEX_CAPTURES
+              value: {{ $.Values.elasticsearch.indexCaptures | quote }}
+            - name: ELASTICSEARCH_INDEX_SERPS
+              value: {{ $.Values.elasticsearch.indexSerps | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
+            - name: S3_ENDPOINT_URL
+              value: {{ $.Values.s3.endpointUrl | quote }}
+            - name: S3_BUCKET_NAME
+              value: {{ $.Values.s3.bucketName | quote }}
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3AccessKey
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-secret
+                  key: s3SecretKey
+            - name: WARC_CACHE_PATH_RESULTS
+              value: {{ $.Values.warcCache.pathResults | quote }}
+          volumeMounts:
+            - name: {{ $.Release.Name }}-warc-cache-path-results
+              mountPath: {{ $.Values.warcCache.pathResults }}
+      volumes:
+        - name: {{ $.Release.Name }}-warc-cache-path-results
+          hostPath:
+            path: {{ $.Values.warcCache.pathResults }}
+            type: DirectoryOrCreate

--- a/helm/templates/serps-download-warc.yml
+++ b/helm/templates/serps-download-warc.yml
@@ -32,8 +32,8 @@ spec:
             - serps
             - download
             - warc
-            - --prefetch-limit
-            - '{{ $.Values.serpsDownloadWarc.prefetchLimit }}'
+            - --size
+            - '{{ $.Values.serpsDownloadWarc.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -59,22 +59,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/serps-parse-url-offset.yml
+++ b/helm/templates/serps-parse-url-offset.yml
@@ -32,8 +32,8 @@ spec:
             - serps
             - parse
             - url-offset
-            - --prefetch-limit
-            - '{{ $.Values.serpsParseUrlOffset.prefetchLimit }}'
+            - --size
+            - '{{ $.Values.serpsParseUrlOffset.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -59,22 +59,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/serps-parse-url-page.yml
+++ b/helm/templates/serps-parse-url-page.yml
@@ -32,8 +32,8 @@ spec:
             - serps
             - parse
             - url-page
-            - --prefetch-limit
-            - '{{ $.Values.serpsParseUrlPage.prefetchLimit }}'
+            - --size
+            - '{{ $.Values.serpsParseUrlPage.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -59,22 +59,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/serps-parse-url-query.yml
+++ b/helm/templates/serps-parse-url-query.yml
@@ -32,8 +32,8 @@ spec:
             - serps
             - parse
             - url-query
-            - --prefetch-limit
-            - '{{ $.Values.serpsParseUrlQuery.prefetchLimit }}'
+            - --size
+            - '{{ $.Values.serpsParseUrlQuery.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -59,22 +59,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/serps-parse-warc-features.yml
+++ b/helm/templates/serps-parse-warc-features.yml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Release.Name }}-serps-parse-warc-snippets
+  name: {{ $.Release.Name }}-serps-parse-warc-features
   namespace: {{ $.Release.Namespace }}
   annotations:
     checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 spec:
   selector:
     matchLabels:
-      app: {{ $.Release.Name }}-serps-parse-warc-snippets
-  replicas: {{ $.Values.serpsParseWarcSnippets.replicas }}
+      app: {{ $.Release.Name }}-serps-parse-warc-features
+  replicas: {{ $.Values.serpsParseWarcFeatures.replicas }}
   revisionHistoryLimit: 1
   template:
     metadata:
       labels:
-        app: {{ $.Release.Name }}-serps-parse-warc-snippets
+        app: {{ $.Release.Name }}-serps-parse-warc-features
     spec:
       containers:
-        - name: {{ $.Release.Name }}-serps-parse-warc-snippets
+        - name: {{ $.Release.Name }}-serps-parse-warc-features
           image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           resources:
@@ -31,9 +31,9 @@ spec:
             - archive_query_log
             - serps
             - parse
-            - warc-snippets
-            - --prefetch-limit
-            - '{{ $.Values.serpsParseWarcSnippets.prefetchLimit }}'
+            - warc-features
+            - --size
+            - '{{ $.Values.serpsParseWarcFeatures.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -59,22 +59,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/serps-parse-warc-organic-results.yml
+++ b/helm/templates/serps-parse-warc-organic-results.yml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Release.Name }}-serps-parse-warc-query
+  name: {{ $.Release.Name }}-serps-parse-warc-organic-results
   namespace: {{ $.Release.Namespace }}
   annotations:
     checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 spec:
   selector:
     matchLabels:
-      app: {{ $.Release.Name }}-serps-parse-warc-query
-  replicas: {{ $.Values.serpsParseWarcQuery.replicas }}
+      app: {{ $.Release.Name }}-serps-parse-warc-organic-results
+  replicas: {{ $.Values.serpsParseWarcOrganicResults.replicas }}
   revisionHistoryLimit: 1
   template:
     metadata:
       labels:
-        app: {{ $.Release.Name }}-serps-parse-warc-query
+        app: {{ $.Release.Name }}-serps-parse-warc-organic-results
     spec:
       containers:
-        - name: {{ $.Release.Name }}-serps-parse-warc-query
+        - name: {{ $.Release.Name }}-serps-parse-warc-organic-results
           image: "{{ .Values.image }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           resources:
@@ -31,9 +31,9 @@ spec:
             - archive_query_log
             - serps
             - parse
-            - warc-query
+            - warc-organic-results
             - --size
-            - '{{ $.Values.serpsParseWarcQuery.size }}'
+            - '{{ $.Values.serpsParseWarcOrganicResults.size }}'
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}

--- a/helm/templates/serps-upload-warc.yml
+++ b/helm/templates/serps-upload-warc.yml
@@ -57,22 +57,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/templates/sources-build.yml
+++ b/helm/templates/sources-build.yml
@@ -31,6 +31,8 @@ spec:
             - archive_query_log
             - sources
             - build
+            - --no-skip-archives
+            - --no-skip-providers
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ $.Values.elasticsearch.host | quote }}
@@ -56,22 +58,10 @@ spec:
               value: {{ $.Values.elasticsearch.indexCaptures | quote }}
             - name: ELASTICSEARCH_INDEX_SERPS
               value: {{ $.Values.elasticsearch.indexSerps | quote }}
-            - name: ELASTICSEARCH_INDEX_RESULTS
-              value: {{ $.Values.elasticsearch.indexResults | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_PAGE_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlPageParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_URL_OFFSET_PARSERS
-              value: {{ $.Values.elasticsearch.indexUrlOffsetParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_QUERY_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcQueryParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_SNIPPETS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcSnippetsParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_DIRECT_ANSWERS_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcDirectAnswersParsers | quote }}
-            - name: ELASTICSEARCH_INDEX_WARC_MAIN_CONTENT_PARSERS
-              value: {{ $.Values.elasticsearch.indexWarcMainContentParsers | quote }}
+            - name: ELASTICSEARCH_INDEX_ORGANIC_RESULTS
+              value: {{ $.Values.elasticsearch.indexOrganicResults | quote }}
+            - name: ELASTICSEARCH_INDEX_FEATURES
+              value: {{ $.Values.elasticsearch.indexFeatures | quote }}
             - name: S3_ENDPOINT_URL
               value: {{ $.Values.s3.endpointUrl | quote }}
             - name: S3_BUCKET_NAME

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,6 +45,21 @@ serpsParseWarcSnippets:
   # replicas: 50
   prefetchLimit: 1000
 
+organicResultsFetchCaptures:
+  replicas: 1
+  size: 1000
+
+organicResultsDownloadWarcBeforeSerp:
+  replicas: 500
+  size: 1000
+
+organicResultsDownloadWarcAfterSerp:
+  replicas: 500
+  size: 1000
+
+organicResultsUploadWarc:
+  replicas: 1
+
 monitoring:
   ingressClassName: nginx
   host: aql-monitoring.srv.webis.de
@@ -71,6 +86,8 @@ elasticsearch:
   indexWarcSnippetsParsers: aql_warc_snippets_parsers
   indexWarcDirectAnswersParsers: aql_warc_direct_answers_parser
   indexWarcMainContentParsers: aql_warc_main_content_parser
+  indexOrganicResults: aql_organic_results
+  indexFeatures: aql_features
 
 s3:
   endpointUrl: https://s3.dw.webis.de
@@ -80,6 +97,7 @@ s3:
 
 warcCache:
   pathSerps: /mnt/ceph/storage/data-in-progress/data-research/web-search/archive-query-log/cache/warc/serps
+  pathResults: /mnt/ceph/storage/data-in-progress/data-research/web-search/archive-query-log/cache/warc/results
 
 browser:
   frontend:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,7 @@ sourcesBuild:
 capturesFetch:
   replicas: 1
   # replicas: 25
-  prefetchLimit: 1000
+  size: 1000
 
 capturesImportAql22:
   enabled: false
@@ -18,19 +18,19 @@ capturesImportAql22:
 
 serpsParseUrlQuery:
   replicas: 100
-  prefetchLimit: 1000
+  size: 1000
 
 serpsParseUrlPage:
   replicas: 2
-  prefetchLimit: 1000
+  size: 1000
 
 serpsParseUrlOffset:
   replicas: 2
-  prefetchLimit: 1000
+  size: 1000
 
 serpsDownloadWarc:
   replicas: 500
-  prefetchLimit: 1000
+  size: 1000
 
 serpsUploadWarc:
   replicas: 1
@@ -38,12 +38,17 @@ serpsUploadWarc:
 
 serpsParseWarcQuery:
   replicas: 50
-  prefetchLimit: 1000
+  size: 1000
 
-serpsParseWarcSnippets:
+serpsParseWarcOrganicResults:
   replicas: 0
   # replicas: 50
-  prefetchLimit: 1000
+  size: 1000
+
+serpsParseWarcFeatures:
+  replicas: 0
+  # replicas: 50
+  size: 1000
 
 organicResultsFetchCaptures:
   replicas: 1
@@ -78,14 +83,6 @@ elasticsearch:
   indexSources: aql_sources
   indexCaptures: aql_captures
   indexSerps: aql_serps
-  indexResults: aql_results
-  indexUrlQueryParsers: aql_url_query_parsers
-  indexUrlPageParsers: aql_url_page_parsers
-  indexUrlOffsetParsers: aql_url_offset_parsers
-  indexWarcQueryParsers: aql_warc_query_parsers
-  indexWarcSnippetsParsers: aql_warc_snippets_parsers
-  indexWarcDirectAnswersParsers: aql_warc_direct_answers_parser
-  indexWarcMainContentParsers: aql_warc_main_content_parser
   indexOrganicResults: aql_organic_results
   indexFeatures: aql_features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "diskcache~=5.6",
     "elasticsearch~=7.17",
     "elasticsearch-dsl~=7.4",
-    "elasticsearch-pydantic~=1.1",
+    "elasticsearch-pydantic~=1.1,>=1.1.1",
     "expiringdict~=1.2",
     "fastapi>=0.121.2,<0.138.0",
     "fastmcp~=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "diskcache~=5.6",
     "elasticsearch~=7.17",
     "elasticsearch-dsl~=7.4",
-    "elasticsearch-pydantic~=1.1,>=1.1.1",
+    "elasticsearch-pydantic~=1.1",
     "expiringdict~=1.2",
     "fastapi>=0.121.2,<0.138.0",
     "fastmcp~=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
     { name = "Benno Stein", email = "benno.stein@uni-weimar.de" },
     { name = "Matthias Hagen", email = "matthias.hagen@uni-jena.de" },
     { name = "Martin Potthast", email = "martin.potthast@uni-kassel.de" },
+    { name = "Ben Gerhards", email = "ben.gerhards@uni-kassel.de" },
 ]
 description = "Mining Millions of Search Result Pages of Hundreds of Search Engines from 25 Years of Web Archives."
 readme = "README.md"

--- a/tests/test_organic_result_actions.py
+++ b/tests/test_organic_result_actions.py
@@ -1,11 +1,16 @@
 from datetime import UTC, datetime
+from io import BytesIO
 from uuid import UUID
 
 from pydantic import HttpUrl
 from pytest import mark
+from warcio.recordloader import ArcWarcRecord
+from warcio.statusandheaders import StatusAndHeaders
 
 from archive_query_log.captures import _organic_result_capture_update_action
 from archive_query_log.downloaders.warc import (
+    _PseudoOrganicResult,
+    _WrapperWarcRecord,
     _organic_result_warc_update_action,
 )
 from archive_query_log.orm import (
@@ -37,6 +42,12 @@ def _inner_capture(timestamp: datetime) -> InnerCapture:
 
 def _warc_location() -> WarcLocation:
     return WarcLocation(file="test.warc.gz", offset=0, length=100)
+
+
+def _dummy_warc_record() -> ArcWarcRecord:
+    return ArcWarcRecord(
+        "warc", "resource", StatusAndHeaders("", []), BytesIO(b""), None, None, 0
+    )
 
 
 def _organic_result(
@@ -189,3 +200,32 @@ def test_capture_update_action_treats_sides_independently() -> None:
     assert "warc_downloader_before_serp" not in action["doc"]
     assert action["doc"]["warc_location_after_serp"] is None
     assert action["doc"]["warc_downloader_after_serp"] is None
+
+
+@mark.parametrize("before_serp", [True, False])
+def test_pseudo_organic_result_round_trips_through_wrapper(before_serp: bool) -> None:
+    """
+    The before/after-SERP side must survive being wrapped into the
+    WARC-Wrapped header and read back, both immediately and after being
+    re-wrapped by its type alone (as happens when re-reading from the WARC
+    cache), since both before-SERP and after-SERP downloads share one cache.
+    """
+    pseudo_result = _PseudoOrganicResult(
+        id=UUID(int=1),
+        index="organic_results",
+        seq_no=7,
+        before_serp=before_serp,
+    )
+
+    # Simulates writing the record to the WARC cache.
+    written: _WrapperWarcRecord[_PseudoOrganicResult] = _WrapperWarcRecord(
+        _dummy_warc_record(), pseudo_result
+    )
+    assert written.wrapped == pseudo_result
+
+    # Simulates re-reading the cached record later, when only the type
+    # (not the original instance) is known.
+    reread = _WrapperWarcRecord(written, _PseudoOrganicResult)
+
+    assert reread.wrapped == pseudo_result
+    assert reread.wrapped.before_serp is before_serp


### PR DESCRIPTION
Approve [#257 ] first.
Add a cache for the organic results, the same way as for the serps.
Fix some additional bugs. See the commit massages for them.
Created helm templates for the organic results pipeline.
Updated stale template files.
